### PR TITLE
Feat: 그룹웨어 로그아웃 시 Roundcube 동시 로그아웃 처리

### DIFF
--- a/src/main/resources/templates/auth/change-password.html
+++ b/src/main/resources/templates/auth/change-password.html
@@ -564,6 +564,13 @@
                 document.cookie = 'accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
                 document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
 
+                // 메일 로그아웃
+                window.open(
+                        "http://techx.kro.kr:8081/roundcube/?_task=login&_action=force-logout",
+                        "roundcubeLogout",
+                        "width=1,height=1,top=99999,left=99999,resizable=no,scrollbars=no,status=no,toolbar=no,menubar=no"
+                );
+
               })
               .catch(error => {
                 console.error('로그아웃 요청 중 오류:', error);

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -606,6 +606,13 @@
                             document.cookie = 'accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
                             document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
 
+                            // 메일 로그아웃
+                            window.open(
+                                "http://techx.kro.kr:8081/roundcube/?_task=login&_action=force-logout",
+                                "roundcubeLogout",
+                                "width=1,height=1,top=99999,left=99999,resizable=no,scrollbars=no,status=no,toolbar=no,menubar=no"
+                            );
+
                             // 인트로 페이지로 이동
                             window.location.href = '/';
                         })


### PR DESCRIPTION
- 클라이언트 측에서 로그아웃 발생 시 Roundcube 로그아웃 URL도 함께 호출되도록 처리

- Roundcube가 그룹웨어와 다른 도메인에 존재하여 서버 측 세션 강제 종료 불가능

- 이를 해결하기 위해 Roundcube에 force_logout PHP 플러그인을 제작하고, 해당 플러그인을 통해 세션 종료 및 리다이렉트 처리