### PR TITLE
개인 주소록 연락처 수정 기능 추가 및 주소록·마이페이지 오류 수정

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
@@ -106,4 +106,23 @@ public class ContactApiController {
     }
 
 
+    /**
+     * 개인 주소록 연락처 수정
+     */
+    @PutMapping("/personal/{id}")
+    public ResponseEntity<Void> updatePersonalContact(
+            @PathVariable int id,
+            @RequestBody PersonalContactDTO dto
+    ) {
+        try {
+            dto.setId(id); // id 바인딩
+            contactService.updatePersonalContact(dto);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -24,4 +24,7 @@ public interface ContactMapper {
     // 개인주소록 연락처 삭제
     void deleteContactsByIds(@Param("ids") List<Integer> ids);
 
+    // 개인주소록 연락처 수정
+    void updatePersonalContact(@Param("contact") PersonalContactDTO dto);
+
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
@@ -49,6 +49,12 @@ public class ContactService {
         contactMapper.deleteContactsByIds(ids);
     }
 
+    /**
+     * 개인 주소록 연락처 수정
+     */
+    public void updatePersonalContact(PersonalContactDTO dto) {
+        contactMapper.updatePersonalContact(dto);
+    }
 
 
 }

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -79,5 +79,15 @@
             </foreach>
     </delete>
 
+    <!-- 개인주소록 연락처 수정 -->
+    <update id="updatePersonalContact" parameterType="com.example.projectdemo.domain.contact.dto.PersonalContactDTO">
+        UPDATE personal_contacts
+        SET
+            name = #{contact.name},
+            email = #{contact.email},
+            phone = #{contact.phone},
+            memo = #{contact.memo}
+        WHERE id = #{contact.id}
+    </update>
 
 </mapper>

--- a/src/main/resources/static/assets/js/contact/contact.js
+++ b/src/main/resources/static/assets/js/contact/contact.js
@@ -16,7 +16,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // 주소 추가 버튼
     document.querySelector('.add-contact-btn').addEventListener('click', function () {
-        document.getElementById('contact-modal').classList.remove('hidden');
+        const modal = document.getElementById('contact-modal');
+        modal.removeAttribute('data-mode');
+        modal.removeAttribute('data-id');
+
+        modal.classList.remove('hidden');
     });
 
     // 주소 추가 취소 버튼
@@ -67,27 +71,53 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const contactData = { name, email, phone, memo };
 
-        fetch('/api/contact/personal/add', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(contactData)
-        })
-            .then(response => {
-                resetContactForm()
+        const modal = document.getElementById('contact-modal');
+        const mode = modal.getAttribute('data-mode');
 
-                if (response.status === 201) {
-                    document.getElementById('contact-modal').classList.add('hidden');
+        if (mode === 'edit') {
+            const id = modal.getAttribute('data-id');
 
-                    loadContacts('personal', 'all');
-                    updateActiveSidebarItem('personal', 'all');
-                } else {
-                    alert('저장에 실패했습니다.');
-                }
+            fetch(`/api/contact/personal/${id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(contactData)
             })
-            .catch(error => {
-                console.error('저장 중 오류 발생:', error);
-                alert('서버 오류로 저장에 실패했습니다.');
-            });
+                .then(res => {
+                    if (res.ok) {
+                        resetContactForm();
+                        modal.classList.add('hidden');
+                        loadContacts('personal', 'all');
+                    } else {
+                        alert('수정에 실패했습니다.');
+                    }
+                })
+                .catch(error => {
+                    console.error('수정 중 오류 발생:', error);
+                    alert('서버 오류로 수정에 실패했습니다.');
+                });
+
+        } else {
+            // 추가일 경우 기존 POST 요청 유지
+            fetch('/api/contact/personal/add', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(contactData)
+            })
+                .then(res => {
+                    resetContactForm();
+
+                    if (res.status === 201) {
+                        modal.classList.add('hidden');
+                        loadContacts('personal', 'all');
+                    } else {
+                        alert('저장에 실패했습니다.');
+                    }
+                })
+                .catch(error => {
+                    console.error('저장 중 오류 발생:', error);
+                    alert('서버 오류로 저장에 실패했습니다.');
+                });
+        }
     });
 
     // 개인 주소록 삭제 이벤트
@@ -131,6 +161,33 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
 
+    // 개인 주소록 상세 보기 모달 수정 버튼 이벤트리스너
+    document.getElementById('editContactBtn').addEventListener('click', function () {
+        const contact = this.contactData;
+
+        if (!contact) return;
+
+        // input에 값 세팅
+        document.getElementById('nameInput').value = contact.name || '';
+        document.getElementById('emailInput').value = contact.email || '';
+        document.getElementById('phoneInput').value = contact.phone || '';
+        document.getElementById('memoInput').value = contact.memo || '';
+        document.getElementById('char-count').textContent = contact.memo?.length || 0;
+
+        // 수정 모드로 세팅
+        const modal = document.getElementById('contact-modal');
+        modal.setAttribute('data-mode', 'edit');
+        modal.setAttribute('data-id', contact.id);
+
+        document.getElementById('saveContactBtn').textContent = '수정';
+
+        // 모달 전환
+        document.getElementById('contact-detail-modal').classList.add('hidden');
+        modal.classList.remove('hidden');
+    });
+
+
+
     // 전체 선택 체크박스 이벤트
     document.addEventListener('change', function (e) {
         if (e.target.classList.contains('select-all-checkbox')) {
@@ -160,6 +217,8 @@ function resetContactForm() {
     document.getElementById('phoneInput').value = '';
     document.getElementById('memoInput').value = '';
     document.getElementById('char-count').textContent = '0';
+    document.getElementById('saveContactBtn').textContent = '저장';
+
 }
 
 // 부서 목록 불러오기
@@ -357,17 +416,27 @@ function openDetailModal(contact, tab) {
     setFieldVisibility('detailEmail', tab === 'shared' ? contact.internalEmail : contact.email);
     setFieldVisibility('detailPhone', contact.phone);
 
+    const editBtn = document.getElementById('editContactBtn');
+
     if (tab === 'shared') {
         document.getElementById('sharedOnly').style.display = '';
         document.getElementById('personalOnly').style.display = 'none';
 
         setFieldVisibility('detailDept', contact.depName);
         setFieldVisibility('detailPosition', contact.posTitle);
+
+        // 공유 주소록은 수정 버튼 숨김
+        editBtn.classList.add('hidden');
     } else {
         document.getElementById('sharedOnly').style.display = 'none';
         document.getElementById('personalOnly').style.display = '';
 
         setFieldVisibility('detailMemo', contact.memo);
+
+        // 개인 주소록은 수정 버튼 표시
+        editBtn.classList.remove('hidden');
+        editBtn.setAttribute('data-id', contact.id); // 수정 시 사용할 ID 저장
+        editBtn.contactData = contact;
     }
 
     document.getElementById('contact-detail-modal').classList.remove('hidden');

--- a/src/main/resources/static/assets/js/contact/contact.js
+++ b/src/main/resources/static/assets/js/contact/contact.js
@@ -393,6 +393,10 @@ function updateHeaderForSelection() {
     const thPhone = document.querySelector('.contact-table thead th:nth-child(4)');
     const thInfo = document.querySelector('.contact-table thead .info-col');
 
+    // 현재 탭 확인
+    const urlParams = new URLSearchParams(window.location.search);
+    const tab = urlParams.get('tab') || 'shared';
+
     if (checkedCount > 0) {
         // 나머지 헤더는 텍스트만 숨김
         thEmail.textContent = '';
@@ -405,7 +409,7 @@ function updateHeaderForSelection() {
         // 복원
         thEmail.textContent = '이메일';
         thPhone.textContent = '전화번호';
-        thInfo.textContent = '메모';
+        thInfo.textContent = (tab === 'shared') ? '부서' : '메모';
         thNameCol.textContent = '이름';
     }
 }

--- a/src/main/resources/static/assets/js/mypage/mypage.js
+++ b/src/main/resources/static/assets/js/mypage/mypage.js
@@ -106,7 +106,7 @@ function generateContent(contentName, data) {
       <div class="info-container">
         <div class="info-row">
           <div class="info-label">입사일</div>
-          <div class="info-content" id="hireDate">${data.empNum}</div>
+          <div class="info-content" id="hireDate">${data.hireDate}</div>
         </div>
 
         <div class="info-row">

--- a/src/main/resources/static/assets/js/mypage/mypage.js
+++ b/src/main/resources/static/assets/js/mypage/mypage.js
@@ -168,7 +168,7 @@ function generateContent(contentName, data) {
     
     <div class="info-container">
         <div class="info-row">
-          <div class="info-label">마지막 로그인</div>
+          <div class="info-label">마지막 활동</div>
           <div class="info-content" id="lastLogin">${data.lastLogin}</div>
         </div>
         <div class="info-row">

--- a/src/main/resources/templates/contact/contact.html
+++ b/src/main/resources/templates/contact/contact.html
@@ -137,6 +137,7 @@
 
     <div class="form-footer">
       <button class="contact-form-btn contact-cancel-btn" onclick="closeDetailModal()">닫기</button>
+      <button id="editContactBtn" class="contact-form-btn contact-save-btn hidden">수정</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 주요 기능 및 수정 사항

- 개인 주소록에서 연락처 정보를 수정할 수 있는 기능 추가
- 공유 주소록 테이블에서 '부서' 컬럼 헤더가 '메모'로 잘못 표시되던 문제 수정
- 마이페이지의 입사일 항목에 사번이 출력되던 오류 수정
- 마이페이지 > 보안 탭의 '마지막 로그인' 텍스트를 '마지막 활동'으로 변경
