### PR TITLE
Feat: 공유·개인 주소록 통합 검색 기능 구현

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/contact")
@@ -123,6 +124,28 @@ public class ContactApiController {
         }
     }
 
+
+    /**
+     * 연락처 검색
+     */
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> searchContacts(
+            @RequestParam String query,
+            HttpServletRequest request) {
+        try {
+            // 개인 주소록 검색을 위해 empId 확인 (로그인된 사용자)
+            Integer empId = (Integer) request.getAttribute("id");
+            if (empId == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+            // Service에서 검색 결과(공유, 개인)를 조회
+            Map<String, Object> result = contactService.searchContacts(empId, query);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 
 
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -27,4 +27,11 @@ public interface ContactMapper {
     // 개인주소록 연락처 수정
     void updatePersonalContact(@Param("contact") PersonalContactDTO dto);
 
+    // 공유 주소록(사원 연락처) 검색
+    List<EmployeeContactDTO> searchSharedContacts(@Param("queryPattern") String queryPattern);
+
+    // 개인 주소록 검색 (로그인한 사원의 개인 주소록)
+    List<PersonalContactDTO> searchPersonalContacts(@Param("empId") Integer empId,
+                                                    @Param("queryPattern") String queryPattern);
+
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
@@ -6,7 +6,9 @@ import com.example.projectdemo.domain.contact.mapper.ContactMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class ContactService {
@@ -56,5 +58,21 @@ public class ContactService {
         contactMapper.updatePersonalContact(dto);
     }
 
+    /**
+     * 연락처 검색
+     */
+    public Map<String, Object> searchContacts(Integer empId, String query) {
+        // 검색어를 LIKE 패턴으로 가공 (예: "%검색어%")
+        String queryPattern = "%" + query + "%";
+        // 공유 주소록 검색 (사원 연락처)
+        List<EmployeeContactDTO> sharedResults = contactMapper.searchSharedContacts(queryPattern);
+        // 개인 주소록 검색 (로그인한 사용자)
+        List<PersonalContactDTO> personalResults = contactMapper.searchPersonalContacts(empId, queryPattern);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("shared", sharedResults);
+        result.put("personal", personalResults);
+        return result;
+    }
 
 }

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -90,4 +90,43 @@
         WHERE id = #{contact.id}
     </update>
 
+    <!-- 공유 주소록 검색: 이름, 내부 이메일, 전화번호, 부서명을 대상으로 LIKE 검색 -->
+    <select id="searchSharedContacts" resultType="com.example.projectdemo.domain.contact.dto.EmployeeContactDTO">
+        SELECT
+            employees.emp_num,
+            employees.name,
+            employees.internal_email,
+            employees.phone,
+            employees.dep_id,
+            departments.name AS dep_name,
+            employees.pos_id,
+            positions.title AS pos_title
+        FROM
+            employees
+                JOIN departments ON employees.dep_id = departments.id
+                JOIN positions ON employees.pos_id = positions.id
+        WHERE
+            employees.name LIKE #{queryPattern}
+           OR employees.internal_email LIKE #{queryPattern}
+           OR employees.phone LIKE #{queryPattern}
+           OR departments.name LIKE #{queryPattern}
+        ORDER BY
+            employees.name;
+    </select>
+
+    <!-- 개인 주소록 검색: 이름, 이메일, 전화번호, 메모를 대상으로 LIKE 검색 -->
+    <select id="searchPersonalContacts" resultType="com.example.projectdemo.domain.contact.dto.PersonalContactDTO">
+        SELECT *
+        FROM personal_contacts
+        WHERE emp_id = #{empId}
+          AND (
+            name LIKE #{queryPattern}
+                OR email LIKE #{queryPattern}
+                OR phone LIKE #{queryPattern}
+                OR memo LIKE #{queryPattern}
+            )
+        ORDER BY name;
+    </select>
+
+
 </mapper>

--- a/src/main/resources/static/assets/css/contact/contact.css
+++ b/src/main/resources/static/assets/css/contact/contact.css
@@ -105,7 +105,7 @@ main {
 
 /* 테이블 스타일 */
 .contact-table {
-    width: 100%;
+    width: 1550px;
     border-collapse: collapse;
     background: #fff;
     padding-left: 40px;
@@ -265,4 +265,26 @@ main {
     border: none;
     cursor: pointer;
     font-size: 15px;
+}
+
+/* 검색 섹션 */
+.search-section {
+    margin-bottom: 20px;
+}
+
+/* 드롭다운 헤더 */
+.search-section-header {
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background-color: #f3f7fb;
+}
+
+/* 검색 테이블 공통 */
+.search-section .contact-table {
+    margin-bottom: 10px;
 }

--- a/src/main/resources/templates/contact/contact.html
+++ b/src/main/resources/templates/contact/contact.html
@@ -37,12 +37,12 @@
     <!-- 검색창 -->
     <div class="search-container">
       <span class="search-icon">🔍</span>
-      <input type="text" id="searchInput" placeholder="이름, 이메일, 전화번호 검색">
-      <button class="search-input-del-button">×</button>
+      <input type="text" id="searchInput" placeholder="이름, 이메일, 전화번호, 부서, 메모 검색">
+      <button class="search-input-del-button" id="searchInputDelBtn">×</button>
     </div>
 
     <!-- 주소록 테이블 -->
-    <table class="contact-table" do="">
+    <table class="contact-table" id="mainContactTable">
       <thead>
       <tr>
         <th class="cel">


### PR DESCRIPTION
- 이름, 이메일, 전화번호, 부서, 메모 기준으로 검색 가능

- 검색 결과를 공유 주소록과 개인 주소록 영역에 맞게 구분하여 출력


### 주요 기능
- 공유 주소록과 개인 주소록 모두를 대상으로 하는 통합 검색 기능 구현
- 이름, 이메일, 전화번호, 부서, 메모 항목을 기준으로 검색 가능
- 검색 결과는 공유 주소록과 개인 주소록 섹션으로 나누어 구분 출력

### 구현 내용
- 검색어는 URL 파라미터로 유지되어 새로고침 및 페이지 이동 시에도 유지됨
- 공유/개인 주소록 각각의 검색 결과를 검색 조건에 따라 동적으로 렌더링
- 탭 클릭 시 검색어와 상관없이 원래 리스트로 돌아가도록 처리

### 테스트 방법
1. 주소록 페이지에서 이름, 부서, 메모 등 다양한 검색어 입력
2. 공유·개인 주소록 영역 각각에 해당 결과가 올바르게 표시되는지 확인
3. 검색 후 탭 전환 시 검색 결과가 제거되고 기본 리스트가 나타나는지 확인
