### PR TITLE
Roundcube 공유 주소록 연동을 위한 DTO 추가 및 자동 등록 기능 구현

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
@@ -1,0 +1,19 @@
+package com.example.projectdemo.domain.contact.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoundcubeContactDTO {
+    private String name;
+    private String email;
+    private String firstname;
+    private String vcard;
+    private String words;
+    private Integer userId;
+}

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -2,6 +2,7 @@ package com.example.projectdemo.domain.contact.mapper;
 
 import com.example.projectdemo.domain.contact.dto.EmployeeContactDTO;
 import com.example.projectdemo.domain.contact.dto.PersonalContactDTO;
+import com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -33,5 +34,8 @@ public interface ContactMapper {
     // 개인 주소록 검색 (로그인한 사원의 개인 주소록)
     List<PersonalContactDTO> searchPersonalContacts(@Param("empId") Integer empId,
                                                     @Param("queryPattern") String queryPattern);
+
+    // 사원 연락처 정보 roundcube 공유 주소록에 추가
+    int insertSharedContact(RoundcubeContactDTO contact); // prefix 안 줌
 
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
@@ -2,7 +2,12 @@ package com.example.projectdemo.domain.contact.service;
 
 import com.example.projectdemo.domain.contact.dto.EmployeeContactDTO;
 import com.example.projectdemo.domain.contact.dto.PersonalContactDTO;
+import com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO;
 import com.example.projectdemo.domain.contact.mapper.ContactMapper;
+import com.example.projectdemo.domain.employees.dto.EmployeesDTO;
+import com.example.projectdemo.domain.employees.mapper.DepartmentsMapper;
+import com.example.projectdemo.domain.employees.mapper.EmployeesMapper;
+import com.example.projectdemo.domain.employees.mapper.PositionsMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +19,12 @@ import java.util.Map;
 public class ContactService {
     @Autowired
     private ContactMapper contactMapper;
+
+    @Autowired
+    private PositionsMapper positionsMapper;
+
+    @Autowired
+    private DepartmentsMapper departmentsMapper;
 
     /**
      * 공유주소록(사원연락처) 조회
@@ -75,4 +86,35 @@ public class ContactService {
         return result;
     }
 
+    /**
+     * 사원 연락처 정보 roundcube 공유 주소록에 추가
+     */
+    public void registerToSharedAddressBook(String name, String email, String phone, String positionTitle, String departmentName) {
+
+        String vcard = String.join("\n",
+                "BEGIN:VCARD",
+                "VERSION:3.0",
+                "N:;" + name + ";;;",
+                "FN:" + name,
+                "EMAIL;TYPE=work:" + email,
+                "TEL;TYPE=cell:" + phone,
+                "TITLE:" + positionTitle,
+                "X-DEPARTMENT:" + departmentName,
+                "END:VCARD"
+        );
+
+
+        String words = name + " " + email + " " + phone.replace("-", "");
+
+        RoundcubeContactDTO contact = RoundcubeContactDTO.builder()
+                .name(name)
+                .email(email)
+                .firstname(name)
+                .vcard(vcard)
+                .words(words)
+                .build();
+
+        contactMapper.insertSharedContact(contact);
+
+    }
 }

--- a/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
+++ b/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
@@ -2,6 +2,7 @@ package com.example.projectdemo.domain.employees.service;
 
 import com.example.projectdemo.config.PasswordEncoder;
 import com.example.projectdemo.domain.auth.service.EmailService;
+import com.example.projectdemo.domain.contact.service.ContactService;
 import com.example.projectdemo.domain.employees.dto.EmployeesDTO;
 import com.example.projectdemo.domain.employees.dto.EmployeesInfoUpdateDTO;
 import com.example.projectdemo.domain.employees.mapper.DepartmentsMapper;
@@ -42,6 +43,9 @@ public class EmployeesService {
 
     @Autowired
     private MailService mailService;
+
+    @Autowired
+    private ContactService contactService;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -204,6 +208,10 @@ public class EmployeesService {
         if (updated <= 0) {
             throw new RuntimeException("회원 정보 업데이트에 실패했습니다.");
         }
+
+        // roundcube(메일클라이언트)의 공유주소록에 사원 정보 등록
+        enrichEmployeeData(employee);
+        contactService.registerToSharedAddressBook(employee.getName(), internalEmail, phone, employee.getPositionTitle(), employee.getDepartmentName());
 
         // 이메일 발송
         emailService.sendTempPasswordEmail(employee.getEmail(), tempPassword);

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -129,4 +129,22 @@
     </select>
 
 
+    <!-- 사원 연락처 정보 roundcube 공유 주소록에 추가 -->
+    <insert id="insertSharedContact" parameterType="com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO">
+        INSERT INTO roundcube.contacts (
+            changed, del, name, email, firstname, vcard, words, user_id
+        )
+        SELECT
+            NOW(),
+            0,
+            #{name},
+            #{email},
+            #{firstname},
+            #{vcard},
+            #{words},
+            u.user_id
+        FROM roundcube.users u
+        WHERE u.username = 'global_addressbook@techx.kro.kr'
+    </insert>
+
 </mapper>


### PR DESCRIPTION
### 주요 변경 사항
- Roundcube 연동을 위한 RoundcubeContactDTO 클래스 추가
  - 이름, 이메일, 전화번호 등 공유 주소록 항목 정보를 담기 위한 DTO 정의

- 신규 사원 가입 시 Roundcube 공유 주소록에 자동 등록되도록 기능 구현
  - EmployeesService에서 ContactService를 호출하여 공유 주소록에 사원 정보를 등록
  - ContactMapper 및 XML 매핑 파일을 통해 DB 연동 처리

### 변경 배경
- 그룹웨어 사용자와 Roundcube 공유 주소록 간 정보 연동을 통해 주소록 자동 관리 및 편의성 향상
- 신규 사원 정보를 반복 입력할 필요 없이 자동으로 웹메일 주소록에 반영되도록 처리

### 테스트 방법
1. 신규 계정 가입 시 공유 주소록에 자동으로 사원 정보가 추가되는지 확인
2. Roundcube 주소록 화면에서 새 사원 정보가 정상적으로 보이는지 확인
