### PR TITLE
그룹웨어 개인 주소록과 Roundcube 주소록 연동 기능 추가 (등록/수정/삭제)

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
@@ -93,8 +93,9 @@ public class ContactApiController {
      * 개인 주소록 연락처 삭제
      */
     @DeleteMapping("/personal/delete")
-    public ResponseEntity<Void> deletePersonalContacts(@RequestBody List<Integer> ids) {
+    public ResponseEntity<Void> deletePersonalContacts(@RequestBody List<Integer> ids, HttpServletRequest request) {
         try {
+            Integer empId = (Integer) request.getAttribute("id");
             if (ids == null || ids.isEmpty()) {
                 return ResponseEntity.badRequest().build(); // 잘못된 요청
             }

--- a/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/controller/ContactApiController.java
@@ -112,13 +112,9 @@ public class ContactApiController {
      * 개인 주소록 연락처 수정
      */
     @PutMapping("/personal/{id}")
-    public ResponseEntity<Void> updatePersonalContact(
-            @PathVariable int id,
-            @RequestBody PersonalContactDTO dto
-    ) {
+    public ResponseEntity<Void> updatePersonalContact(@PathVariable int id, @RequestBody PersonalContactDTO dto) {
         try {
-            dto.setId(id); // id 바인딩
-            contactService.updatePersonalContact(dto);
+            contactService.updatePersonalContact(id, dto); // id 별도 전달
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/java/com/example/projectdemo/domain/contact/dto/PersonalContactDTO.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/dto/PersonalContactDTO.java
@@ -16,4 +16,5 @@ public class PersonalContactDTO {
     private String email;
     private String phone;
     private String memo;
+    private Integer roundcubeContactId;
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RoundcubeContactDTO {
+    private Integer contactId;
     private String name;
     private String email;
     private String firstname;

--- a/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/dto/RoundcubeContactDTO.java
@@ -16,4 +16,5 @@ public class RoundcubeContactDTO {
     private String vcard;
     private String words;
     private Integer userId;
+    private Integer empId;
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -10,6 +10,9 @@ import java.util.List;
 
 @Mapper
 public interface ContactMapper {
+    // 주소록 id로 roundcube_contact_id 조회
+    Integer findRoundcubeContactIdById(@Param("id") int id);
+
     // 모든 사원의 연락처 정보 조회
     List<EmployeeContactDTO> findAllEmpContacts();
 
@@ -35,7 +38,10 @@ public interface ContactMapper {
     void deleteContactsByIds(@Param("ids") List<Integer> ids);
 
     // 개인주소록 연락처 수정
-    void updatePersonalContact(@Param("contact") PersonalContactDTO dto);
+    void updatePersonalContact(PersonalContactDTO contact);
+
+    // roundcube 연락처 수정
+    void updateRoundcubeContact(RoundcubeContactDTO contact);
 
     // 공유 주소록(사원 연락처) 검색
     List<EmployeeContactDTO> searchSharedContacts(@Param("queryPattern") String queryPattern);

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -22,6 +22,9 @@ public interface ContactMapper {
     // 개인주소록에 연락처 추가
     void insertPersonalContact(@Param("contact") PersonalContactDTO contact);
 
+    //  개인 주소록에 추가된 연락처 roundcube 주소록에 추가
+    void insertPersonalRoundcubeContact(RoundcubeContactDTO contact);
+
     // 개인주소록 연락처 삭제
     void deleteContactsByIds(@Param("ids") List<Integer> ids);
 

--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -25,6 +25,12 @@ public interface ContactMapper {
     //  개인 주소록에 추가된 연락처 roundcube 주소록에 추가
     void insertPersonalRoundcubeContact(RoundcubeContactDTO contact);
 
+    // personal_contacts.id 리스트 → roundcube_contact_id 리스트 조회
+    List<Integer> findRoundcubeContactIdsByPersonalIds(@Param("ids") List<Integer> ids);
+
+    // roundcube.contacts 삭제
+    void deleteRoundcubeContactsByIds(@Param("ids") List<Integer> rcContactIds);
+
     // 개인주소록 연락처 삭제
     void deleteContactsByIds(@Param("ids") List<Integer> ids);
 

--- a/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
@@ -111,8 +111,52 @@ public class ContactService {
     /**
      * 개인 주소록 연락처 수정
      */
-    public void updatePersonalContact(PersonalContactDTO dto) {
-        contactMapper.updatePersonalContact(dto);
+    @Transactional
+    public void updatePersonalContact(int id, PersonalContactDTO contact) {
+
+        contact.setId(id);
+
+        // roundcube_contact_id 보완
+        Integer rcid = contactMapper.findRoundcubeContactIdById(id);
+        contact.setRoundcubeContactId(rcid);
+
+        // 그룹웨어 DB 업데이트
+        contactMapper.updatePersonalContact(contact);
+
+        // 3. Roundcube 연동 업데이트
+        RoundcubeContactDTO rcContact = toRoundcubeDTO(contact);
+        contactMapper.updateRoundcubeContact(rcContact);
+
+    }
+
+    /**
+     * 연락처 dto roundcube dto로 가공
+     */
+    private RoundcubeContactDTO toRoundcubeDTO(PersonalContactDTO dto) {
+        String vcard = String.join("\n",
+                "BEGIN:VCARD",
+                "VERSION:3.0",
+                "N:;" + dto.getName() + ";;;",
+                "FN:" + dto.getName(),
+                dto.getEmail() != null ? "EMAIL:" + dto.getEmail() : null,
+                dto.getPhone() != null ? "TEL:" + dto.getPhone() : null,
+                dto.getMemo() != null ? "NOTE:" + dto.getMemo() : null,
+                "END:VCARD"
+        ).replaceAll("(?m)^null\\n?", "");
+
+        String words = dto.getName() + " " +
+                (dto.getEmail() != null ? dto.getEmail() : "") + " " +
+                (dto.getPhone() != null ? dto.getPhone().replace("-", "") : "");
+
+
+        return RoundcubeContactDTO.builder()
+                .contactId(dto.getRoundcubeContactId())
+                .name(dto.getName())
+                .email(dto.getEmail())
+                .firstname(dto.getName())
+                .vcard(vcard)
+                .words(words.trim())
+                .build();
     }
 
     /**

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -56,26 +56,20 @@
 
     <!-- 개인주소록에 연락처 추가 -->
     <insert id="insertPersonalContact">
-        INSERT INTO
-            personal_contacts (emp_id, name, email, phone, memo)
-        VALUES
-            (#{contact.empId}, #{contact.name}, #{contact.email}, #{contact.phone}, #{contact.memo})
+        INSERT INTO personal_contacts (emp_id, name, email, phone, memo, roundcube_contact_id)
+        VALUES (#{contact.empId}, #{contact.name}, #{contact.email}, #{contact.phone}, #{contact.memo}, #{contact.roundcubeContactId})
     </insert>
 
     <!-- 개인 주소록에 추가된 연락처 roundcube 주소록에 추가 -->
-    <insert id="insertPersonalRoundcubeContact" parameterType="com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO">
+    <insert id="insertPersonalRoundcubeContact"
+            parameterType="com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO"
+            useGeneratedKeys="true"
+            keyProperty="contactId">
         INSERT INTO roundcube.contacts (
             changed, del, name, email, firstname, vcard, words, user_id
         )
         SELECT
-            NOW(),
-            0,
-            #{name},
-            #{email},
-            #{firstname},
-            #{vcard},
-            #{words},
-            u.user_id
+            NOW(), 0, #{name}, #{email}, #{firstname}, #{vcard}, #{words}, u.user_id
         FROM employees e
                  JOIN roundcube.users u ON u.username = e.internal_email
         WHERE e.id = #{empId}
@@ -88,6 +82,26 @@
         FROM personal_contacts
         WHERE emp_id = #{empId}
     </select>
+
+
+    <!-- personal_contacts → roundcube_contact_id 조회 -->
+    <select id="findRoundcubeContactIdsByPersonalIds" resultType="int">
+        SELECT roundcube_contact_id
+        FROM personal_contacts
+        WHERE id IN
+        <foreach collection="ids" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </select>
+
+    <!-- roundcube.contacts에서 삭제 -->
+    <delete id="deleteRoundcubeContactsByIds">
+        DELETE FROM roundcube.contacts
+        WHERE contact_id IN
+        <foreach collection="ids" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </delete>
 
     <!-- 개인주소록 연락처 삭제 -->
     <delete id="deleteContactsByIds">

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.example.projectdemo.domain.contact.mapper.ContactMapper">
+
+    <!-- 주소록 id로 roundcube_contact_id 조회 -->
+    <select id="findRoundcubeContactIdById" resultType="int">
+        SELECT roundcube_contact_id
+        FROM personal_contacts
+        WHERE id = #{id}
+    </select>
+
     <!-- 모든 사원의 연락처 정보 조회 -->
     <select id="findAllEmpContacts" resultType="com.example.projectdemo.domain.contact.dto.EmployeeContactDTO">
         SELECT
@@ -117,11 +125,23 @@
     <update id="updatePersonalContact" parameterType="com.example.projectdemo.domain.contact.dto.PersonalContactDTO">
         UPDATE personal_contacts
         SET
-            name = #{contact.name},
-            email = #{contact.email},
-            phone = #{contact.phone},
-            memo = #{contact.memo}
-        WHERE id = #{contact.id}
+            name = #{name},
+            email = #{email},
+            phone = #{phone},
+            memo = #{memo}
+        WHERE id = #{id}
+    </update>
+
+    <!-- roundcube 연락처 수정 -->
+    <update id="updateRoundcubeContact" parameterType="com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO">
+        UPDATE roundcube.contacts
+        SET name = #{name},
+            email = #{email},
+            firstname = #{firstname},
+            vcard = #{vcard},
+            words = #{words},
+            changed = NOW()
+        WHERE contact_id = #{contactId}
     </update>
 
     <!-- 공유 주소록 검색: 이름, 내부 이메일, 전화번호, 부서명을 대상으로 LIKE 검색 -->

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -54,13 +54,33 @@
             employees.name;
     </select>
 
-    <!-- 부서별 공유주소록(사원연락처) 조회 -->
+    <!-- 개인주소록에 연락처 추가 -->
     <insert id="insertPersonalContact">
         INSERT INTO
             personal_contacts (emp_id, name, email, phone, memo)
         VALUES
             (#{contact.empId}, #{contact.name}, #{contact.email}, #{contact.phone}, #{contact.memo})
     </insert>
+
+    <!-- 개인 주소록에 추가된 연락처 roundcube 주소록에 추가 -->
+    <insert id="insertPersonalRoundcubeContact" parameterType="com.example.projectdemo.domain.contact.dto.RoundcubeContactDTO">
+        INSERT INTO roundcube.contacts (
+            changed, del, name, email, firstname, vcard, words, user_id
+        )
+        SELECT
+            NOW(),
+            0,
+            #{name},
+            #{email},
+            #{firstname},
+            #{vcard},
+            #{words},
+            u.user_id
+        FROM employees e
+                 JOIN roundcube.users u ON u.username = e.internal_email
+        WHERE e.id = #{empId}
+    </insert>
+
 
     <!-- 개인 주소록(사원 연락처) 조회 -->
     <select id="findPersonalContactsByEmpId" resultType="com.example.projectdemo.domain.contact.dto.PersonalContactDTO">


### PR DESCRIPTION
### 주요 기능
- 그룹웨어에서 개인 주소록에 연락처 추가 시, Roundcube 주소록에도 자동으로 연락처가 등록되도록 연동
- 그룹웨어에서 개인 주소록 정보를 수정하면, Roundcube 주소록 정보도 함께 수정되도록 연동
- 그룹웨어에서 개인 주소록 연락처 삭제 시, Roundcube 주소록에서도 해당 연락처가 함께 삭제되도록 처리

### 세부 구현 내용
- RoundcubeContactDTO에 userId 및 연락처 식별을 위한 필드 추가
- 사용자 계정은 roundcube.users 테이블의 user_id 기준으로 식별
- 주소록 연동은 ContactService 내부에서 처리되며, Roundcube 주소록과 그룹웨어 주소록 간 필드 매핑을 통해 동기화 수행
- 삭제 연동 시 기존 소프트 삭제(del = 1) 방식 대신 실제 삭제(DELETE) 처리되도록 PHP 쿼리 소스 수정

### 변경 배경
- 그룹웨어와 메일 주소록을 분리 관리하지 않고, 사용자 주소록을 Roundcube에도 자동으로 반영하여 편의성과 일관성 확보
- 수동 이중 등록 없이, 하나의 시스템 내에서 통합된 주소록 관리 가능하도록 기능 개선

### 테스트 방법
1. 그룹웨어 개인 주소록에 연락처를 추가하고 Roundcube 주소록에서 반영 여부 확인
2. 그룹웨어에서 연락처를 수정하면 Roundcube 주소록도 함께 변경되는지 확인
3. 그룹웨어에서 연락처를 삭제하면 Roundcube 주소록에서도 해당 항목이 실제로 삭제되는지 확인
