### PR TITLE
Feat: 사내 이메일 자동 생성 시 중복 가능성 확장 고려

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
+++ b/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
@@ -344,19 +344,34 @@ public class EmployeesService {
      * 사내 이메일 생성
      */
     public String generateInternalEmail(String name) {
-        String romanized = KoreanRomanizer.romanize(name, KoreanCharacter.Type.NameTypical); // 예: "강윤진" → "Kang Yunjin"
+        String romanized = KoreanRomanizer.romanize(name, KoreanCharacter.Type.NameTypical);
         String[] parts = romanized.split(" ");
 
-        String lastName = parts[0].toLowerCase(); // 예: kang
-        String firstName = parts[1].toLowerCase(); // 예: yunjin
+        String lastName = parts[0].toLowerCase();
+        String firstName = parts[1].toLowerCase();
+        String domain = "@techx.kro.kr";
 
-        String emailPrefix = firstName.charAt(0) + lastName; // 예: ykang
-
-        if (mailService.emailExists(emailPrefix + "@techx.kro.kr")) {
-            emailPrefix = firstName + lastName; // 예: yunjinkang
+        // 1. ykang
+        String prefix = firstName.charAt(0) + lastName;
+        if (!mailService.emailExists(prefix + domain)) {
+            return prefix + domain;
         }
 
-        return emailPrefix + "@techx.kro.kr";
+        // 2. y.kang
+        prefix = firstName.charAt(0) + "." + lastName;
+        if (!mailService.emailExists(prefix + domain)) {
+            return prefix + domain;
+        }
+
+        // 3. yunjinkang
+        prefix = firstName + lastName;
+        if (!mailService.emailExists(prefix + domain)) {
+            return prefix + domain;
+        }
+
+        // 4. yunjin.kang
+        prefix = firstName + "." + lastName;
+        return prefix + domain;
     }
 
     /**


### PR DESCRIPTION
### 주요 변경 사항
- 사내 이메일 자동 생성 로직 개선
  - 기존에는 중복 가능성을 적게 고려하여 `ykang`, `yunjinkang` 까지만 생성 가능
  - 개선된 로직에서는 중복 가능성을 더 넓게 보고, 다수의 후보 이메일을 생성하여 충돌을 회피
  - ykang -> y.kang -> yunjinkang -> yunjin.kang