### PR TITLE
마이페이지 반응형 레이아웃 구성 및 Roundcube 공유 주소록 연동 기능 추가

### DIFF
--- a/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/mapper/ContactMapper.java
@@ -51,6 +51,9 @@ public interface ContactMapper {
                                                     @Param("queryPattern") String queryPattern);
 
     // 사원 연락처 정보 roundcube 공유 주소록에 추가
-    int insertSharedContact(RoundcubeContactDTO contact); // prefix 안 줌
+    int insertSharedContact(RoundcubeContactDTO contact);
+
+    // 사원정보 변경 시 Roundcube 글로벌 주소록을 업데이트
+    void updateSharedContact(RoundcubeContactDTO contact);
 
 }

--- a/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
+++ b/src/main/java/com/example/projectdemo/domain/contact/service/ContactService.java
@@ -205,6 +205,39 @@ public class ContactService {
                 .build();
 
         contactMapper.insertSharedContact(contact);
-
     }
+
+    /**
+     * 사원정보 변경 시 Roundcube 글로벌 주소록을 업데이트
+     */
+    public void updateSharedAddressBook(EmployeesDTO employee) {
+        String internalEmail = employee.getInternalEmail(); // Roundcube contacts.email과 매칭
+
+        String vcard = String.join("\n",
+                "BEGIN:VCARD",
+                "VERSION:3.0",
+                "N:;" + employee.getName() + ";;;",
+                "FN:" + employee.getName(),
+                "EMAIL;TYPE=work:" + internalEmail,
+                employee.getPhone() != null ? "TEL;TYPE=cell:" + employee.getPhone() : null,
+                employee.getPositionTitle() != null ? "TITLE:" + employee.getPositionTitle() : null,
+                employee.getDepartmentName() != null ? "X-DEPARTMENT:" + employee.getDepartmentName() : null,
+                "END:VCARD"
+        ).replaceAll("(?m)^null\\n?", "");
+
+        String words = employee.getName() + " " + internalEmail + " " +
+                (employee.getPhone() != null ? employee.getPhone().replace("-", "") : "");
+
+        RoundcubeContactDTO contact = RoundcubeContactDTO.builder()
+                .name(employee.getName())
+                .email(internalEmail)
+                .firstname(employee.getName())
+                .vcard(vcard)
+                .words(words.trim())
+                .build();
+
+        contactMapper.updateSharedContact(contact); // userId 없이 호출
+    }
+
+
 }

--- a/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
+++ b/src/main/java/com/example/projectdemo/domain/employees/service/EmployeesService.java
@@ -339,9 +339,15 @@ public class EmployeesService {
     /**
      * 마이페이지 사용자 정보(프로필이미지, 전화번호, 개인이메일) 업데이트
      */
+    @Transactional
     public void updateEmpInfo(String empNum, String phone, String email, String profileImgUrl){
         EmployeesInfoUpdateDTO updatedEmp = new EmployeesInfoUpdateDTO(empNum, phone, email, profileImgUrl);
         employeeMapper.updateEmpInfo(updatedEmp);
+
+        // 공유주소록 사원 주소록 업데이트
+        EmployeesDTO employee = employeeMapper.findByEmpNum(empNum);
+        enrichEmployeeData(employee);
+        contactService.updateSharedAddressBook(employee);
     }
 
     /**

--- a/src/main/resources/mappers/ContactsMapper.xml
+++ b/src/main/resources/mappers/ContactsMapper.xml
@@ -201,4 +201,16 @@
         WHERE u.username = 'global_addressbook@techx.kro.kr'
     </insert>
 
+    <!-- 사원정보 변경 시 Roundcube 글로벌 주소록을 업데이트 -->
+    <update id="updateSharedContact">
+        UPDATE roundcube.contacts
+        SET
+            name = #{name},
+            firstname = #{firstname},
+            vcard = #{vcard},
+            words = #{words}
+        WHERE email = #{email}
+          AND user_id = (SELECT user_id FROM roundcube.users WHERE username = 'global_addressbook@techx.kro.kr')
+    </update>
+
 </mapper>

--- a/src/main/resources/static/assets/css/mypage/mypage.css
+++ b/src/main/resources/static/assets/css/mypage/mypage.css
@@ -405,3 +405,54 @@ tbody .title-col a:hover {
     text-decoration: underline;
 }
 
+
+
+/* 반응형 스타일 */
+@media (max-width: 1200px) {
+    .mypage-sidebar {
+        background-color: #f3f7fb;
+        border-right: 1px solid #e5e5e5;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        display: none;
+    }
+
+    .mypage-sidebar.open {
+        transform: translateX(0);
+        display: block;
+    }
+
+    .main{
+        width: 90vw;
+        max-width: 90vw;
+        height: 90vh;
+    }
+    .main-section {
+        width: 100%;
+        max-width: 100%;
+        margin: 0 auto;
+    }
+
+    #sidebarToggleBtn {
+        position: fixed;
+        bottom: 20px;
+        right: 20px;
+        width: 50px;
+        height: 50px;
+        background-color: #4a90e2;
+        color: white;
+        display: block;
+        justify-content: center;
+        align-items: center;
+        font-size: 24px;
+        z-index: 1100;
+        cursor: pointer;
+    }
+}
+
+/* 1200px 이상일 때만 숨김 */
+@media (min-width: 1201px) {
+    #sidebarToggleBtn {
+        display: none;
+    }
+}

--- a/src/main/resources/static/assets/js/mypage/mypage.js
+++ b/src/main/resources/static/assets/js/mypage/mypage.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     loadTabContent(tab); // 탭에 맞는 내용 로드
-
 });
 
 function loadTabContent(tabName) {
@@ -692,4 +691,9 @@ function setupCommentDelete() {
             })
             .catch(() => alert('오류 발생'));
     });
+}
+
+function toggleSidebar() {
+    const sidebar = document.getElementById('mypageSidebar');
+    sidebar.classList.toggle('open');
 }

--- a/src/main/resources/templates/mypage/mypage.html
+++ b/src/main/resources/templates/mypage/mypage.html
@@ -22,7 +22,7 @@
 <div th:replace="fragments/header :: headerScripts"></div>
 
 <main>
-  <div class="mypage-sidebar">
+  <div class="mypage-sidebar" id="mypageSidebar">
     <div class="mypage-sidebar-item" id="info" onclick="loadTabContent('info')">
       <span class="mypage-sidebar-icon"><i class="fa-solid fa-user"></i></span>
       <span class="mypage-sidebar-link">내 정보</span>
@@ -37,11 +37,13 @@
     </div>
   </div>
 
-  <section class="main-section" id="mainSection">
-
-  </section>
-  
-
+  <section class="main-section" id="mainSection"></section>
 </main>
+<!-- 사이드바 토글 버튼 (1200px 이하일 때만 표시됨) -->
+<button id="sidebarToggleBtn" onclick="toggleSidebar()">
+
+</button>
+
+
 </body>
 </html>


### PR DESCRIPTION
### 주요 변경 사항
- 마이페이지 반응형 레이아웃 구성 (미완성)
  - 화면 너비가 1200px 이하일 경우 사이드바 자동으로 숨김 처리
  - 우측 하단에 사이드바 열기 버튼 추가
  - main-section 가운데 정렬 등 레이아웃 일부 반응형 적용

- 마이페이지 정보 수정 시 Roundcube 공유 주소록도 함께 수정되도록 연동
  - EmployeesService의 마이페이지 정보 수정 로직 내부에서 Roundcube 주소록 수정도 함께 수행
  - 이름, 전화번호 등의 정보가 변경되면 Roundcube 글로벌 주소록 내 해당 사용자 정보도 갱신됨

### 테스트 방법
1. 마이페이지에서 화면 너비 줄였을 때 사이드바 숨김 및 토글 버튼 확인
2. 마이페이지에서 사용자 정보를 수정하고 Roundcube TechX 사원 주소록에서도 정보가 반영되는지 확인
