### PR TITLE
로그인 유지 체크 시에만 메일 자동 로그인 지속되도록 분기 처리

### DIFF
--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -270,8 +270,12 @@
 
   // 메일 자동 로그인 처리
   function mailLogin(user, pass) {
-    const url = `http://techx.kro.kr:8081/roundcube/?_autologin=1&_user=${encodeURIComponent(user)}&_pass=${encodeURIComponent(pass)}`;
-    const popup = window.open(
+    const rememberMe = document.getElementById('remember-me').checked;
+
+    const url = `http://techx.kro.kr:8081/roundcube/?_autologin=1&_user=${encodeURIComponent(user)}&_pass=${encodeURIComponent(pass)}`
+            + (rememberMe ? '&_remember=1' : '&_remember=0');
+
+    window.open(
             url,
             'roundcubeLogin',
             'width=1,height=1,top=99999,left=99999,resizable=no,scrollbars=no,status=no,toolbar=no,menubar=no'


### PR DESCRIPTION
### 주요 변경 사항
- 그룹웨어 로그인 시 '로그인 유지' 체크 여부에 따라 메일(Roundcube) 자동 로그인 세션 유지 여부를 분기 처리
  - 로그인 유지가 체크된 경우: Roundcube에 지속 로그인(7일 유지)
  - 로그인 유지가 체크되지 않은 경우: Roundcube는 일반 세션 로그인

### 변경 배경
- 사용자가 로그인 유지 여부를 선택할 수 있도록 하고, 메일 세션도 이에 맞춰 일관성 있게 동작하도록 개선
- 보안상 일반 로그인 시 메일까지 자동 유지되는 문제 방지

### 테스트 방법
1. 그룹웨어 로그인 시 '로그인 유지' 체크 후 메일 자동 로그인 상태 확인
2. 체크하지 않고 로그인 → 브라우저 재시작 시 메일 세션이 만료되는지 확인