### PR TITLE
게시판 멤버 추가 시 본인이 아닌 다른 사원이 제외되던 문제 수정

### DIFF
--- a/src/main/resources/templates/board/create.html
+++ b/src/main/resources/templates/board/create.html
@@ -483,7 +483,10 @@
                     // 사용자 목록 렌더링
                     data.forEach(user => {
                         // 현재 로그인한 사용자는 제외
-                        if (user.id === parseInt(localStorage.getItem('empNum'))) {
+                        // if (user.id === parseInt(localStorage.getItem('empNum'))) {
+                        //     return;
+                        // }
+                        if (user.empNum === localStorage.getItem('empNum')) {
                             return;
                         }
 


### PR DESCRIPTION
### 주요 수정 사항
- 게시판 생성 또는 멤버 추가 시, 로그인한 사용자를 제외해야 하는 로직에서 조건이 잘못되어 다른 사원이 제외되는 문제 수정
- id와 empNum을 비교하던 기존 코드에서 empNum끼리 비교하도록 조건을 수정하여, 본인만 정확히 제외되도록 처리

### 변경 배경
- 기능 자체는 작동했지만 멤버 목록에 본인이 아닌 다른 사원이 누락되는 문제가 발생했음

### 테스트 방법
1. 게시판 생성 시 멤버 추가 버튼 클릭
2. 본인 계정이 제외되고 나머지 사원이 정확히 표시되는지 확인